### PR TITLE
Avoid util.print, it is deprecated in node v0.11

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -31,7 +31,7 @@ function run(args, env) {
 
   pkg = new slInstall.Installer( path.join(cmd.destination, pkgName) )
 
-  pkg.on('entry', function() { util.print('.') })
+  pkg.on('entry', function() { process.stdout.write('.') })
 
   if (cmd.args.length < 1) {
     slInstall.git.branchList(function(err, branches) {


### PR DESCRIPTION
spews to console during install messages about using console.log instead of util.print

except I assume you are using util.print because you do NOT want the newline, so you have to write to process.stdout, not use console.log
